### PR TITLE
Bump version via GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
         description: 'Release'
         required: true
         default: 'true'
+      new_version:
+        description: 'New version'
+        required: true
+        default: 'patch'
 
 jobs:
   ci:
@@ -31,6 +35,10 @@ jobs:
       - run: npm run test
       - name: Release
         if: ${{ github.event.inputs.release == 'true' }}
-        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}" && npm publish
+        run: |
+          npm version ${{ github.event.inputs.new_version }}
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+          npm publish --dry-run
+          git push origin && git push origin --tags
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           npm version ${{ github.event.inputs.new_version }}
           npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-          npm publish --dry-run
+          npm publish
           git push origin && git push origin --tags
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-build-safety",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-build-safety",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-build-safety",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Make app releases safer. Reduce thinking with automated checks.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "reformat": "npm run eslint -- --fix",
     "eslint": "./node_modules/.bin/eslint '**/*.{js,ts,tsx}' --ignore-path=.gitignore",
     "test": "jest --runInBand --maxConcurrency=1",
-    "prepublishOnly": "git diff --exit-code",
-    "postpublish": "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag $PACKAGE_VERSION && git push origin --tags"
+    "prepublishOnly": "git diff --exit-code"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-build-safety",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Make app releases safer. Reduce thinking with automated checks.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Enable releases with a simple GitHub click.
Our CI checks should be good enough such that local checkouts should be unnecessary.
