### PR TITLE
Relaxed safety checks: Tree hashes in addition to commit hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- To prevent unnecessary failures, look at tree hashes in addition to commit hashes.
+
 ## 1.1.0
 
 - Add command `capsafe disable` to temporarily disable capsafe until branches are switched.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In particular, the following mistakes can lead to broken app releases or wasted 
 `capsafe` is a simple tool that prevents those mistakes.
 For example, `capsafe` prevents broken Android releases with the following message, if a developer forgot to sync Capacitor for the most recent commit:
 
-`error: Current commit 25a7a56bca71 is not equal to commit 8c8476eb77f6 in 'android/app/src/main/assets/public/commit-evidence.json'. Did you forget to build/sync with Capacitor?`
+`error: Current commit 25a7a56bca71 does not match with commit 8c8476eb77f6 in 'android/app/src/main/assets/public/commit-evidence.json'. Did you forget to build/sync with Capacitor?`
 
 Similarly, `capsafe` prevents broken iOS-builds if a developer forgot to do a web-build:
 
@@ -28,9 +28,9 @@ Beside of native apps, `capsafe` is also usable for browser-based tests that run
 `capsafe` provides three commands to prevent broken apps: `create-commit-evidence`, `verify-commit-evidence`, `validate-capacitor-config`.
 Typically, those commands run in the following steps:
 
-- After each web-build, `create-commit-evidence` creates a file `commit-evidence.json` in your web-build folder. `commit-evidence.json` contains the current HEAD-commit hash.
+- After each web-build, `create-commit-evidence` creates a file `commit-evidence.json` in your web-build folder. `commit-evidence.json` contains information about the current HEAD-commit (the tree hash and the commit hash).
 - Naturally, Capacitor-commands like `cap sync` copy `commit-evidence.json` to native asset directories, along with all other web-assets.
-- Later on, during each native app build, `verify-commit-evidence` verifies that the current HEAD-commit is still equal to the commit in `commit-evidence.json` in the respective native asset directory.
+- Later on, during each native app build, `verify-commit-evidence` verifies that the current HEAD-commit still matches with `commit-evidence.json` in the respective native asset directory.
 - `validate-capacitor-config` runs before each app release or in a continuous integration pipeline.
 
 ## Disable checks temporarily

--- a/src/commit-evidence/common.ts
+++ b/src/commit-evidence/common.ts
@@ -2,6 +2,7 @@ import { joinDirWithFileName } from '../util';
 
 export interface CommitEvidence {
   commitHash: string;
+  treeHash: string;
   created: string;
 }
 

--- a/src/commit-evidence/create-commit-evidence.ts
+++ b/src/commit-evidence/create-commit-evidence.ts
@@ -7,7 +7,8 @@ export function createCommitEvidence(
   buildDir: string,
 ): void {
   const evidence: CommitEvidence = {
-    commitHash: context.gitContext.currentCommit,
+    commitHash: context.gitContext.currentCommitHash,
+    treeHash: context.gitContext.currentTreeHash,
     created: new Date().toISOString(),
   };
   const evidencePath = getCommitEvidencePath(buildDir);

--- a/src/commit-evidence/verify-commit-evidence.ts
+++ b/src/commit-evidence/verify-commit-evidence.ts
@@ -15,18 +15,56 @@ export function verifyCommitEvidence(
   if (!evidence.commitHash) {
     logFatal(`Did not find a commit hash in ${getDebugPath(evidencePath)}.`);
   }
-  const currentCommit = context.gitContext.currentCommit;
-  const evidenceCommit = evidence.commitHash;
-  if (currentCommit !== evidenceCommit) {
+
+  if (checkCommitHashes(evidence, evidencePath, context)) {
+    return;
+  } else if (checkTreeHashes(evidence, evidencePath, context)) {
+    return; // If commit hashes are not matching, then the tree hashes might still match.
+  } else {
+    const currentCommit = context.gitContext.currentCommitHash;
+    const evidenceCommit = evidence.commitHash;
     logFatal(
-      `Current commit ${currentCommit} is not equal to commit ${evidenceCommit} in ${getDebugPath(
+      `Current commit ${currentCommit} does not match with commit ${evidenceCommit} in ${getDebugPath(
         evidencePath,
       )}. Did you forget to build/sync with Capacitor?`,
     );
   }
-  console.log(
-    `Verification succeeded: ${getDebugPath(
-      evidencePath,
-    )} is up-to-date with current commit ${currentCommit}.`,
-  );
+}
+
+function checkCommitHashes(
+  evidence: Partial<CommitEvidence>,
+  evidencePath: string,
+  context: CapSafeContext,
+): boolean {
+  const currentCommit = context.gitContext.currentCommitHash;
+  const evidenceCommit = evidence.commitHash;
+  if (currentCommit === evidenceCommit) {
+    console.log(
+      `Verification succeeded: ${getDebugPath(
+        evidencePath,
+      )} is up-to-date with current commit ${currentCommit}.`,
+    );
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function checkTreeHashes(
+  evidence: Partial<CommitEvidence>,
+  evidencePath: string,
+  context: CapSafeContext,
+): boolean {
+  const currentTree = context.gitContext.currentTreeHash;
+  const evidenceTree = evidence.treeHash;
+  if (currentTree === evidenceTree) {
+    console.log(
+      `Verification succeeded: ${getDebugPath(
+        evidencePath,
+      )} is up-to-date with current tree ${currentTree}.`,
+    );
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/src/git-context.ts
+++ b/src/git-context.ts
@@ -2,18 +2,21 @@ import { runCommandOrDie } from './util';
 
 export interface GitContext {
   gitRootDir: string;
-  currentCommit: string;
+  currentCommitHash: string;
+  currentTreeHash: string;
   currentBranch: string;
 }
 
 export function resolveGitContext(): GitContext {
-  // Order commands with ascending complexity.
+  // The first command is important for error messages.
   const gitRootDir = getGitRootDir();
-  const currentCommit = getHEADCommitHash();
+  const currentCommitHash = getHEADCommitHash();
+  const currentTreeHash = getHEADTreeHash();
   const currentBranch = getCurrentBranch();
   return {
     gitRootDir,
-    currentCommit,
+    currentCommitHash,
+    currentTreeHash,
     currentBranch,
   };
 }
@@ -24,6 +27,10 @@ function getGitRootDir(): string {
 
 export function getHEADCommitHash(): string {
   return runCommandOrDie('git rev-parse HEAD').trim();
+}
+
+export function getHEADTreeHash(): string {
+  return runCommandOrDie('git rev-parse HEAD^{tree}').trim();
 }
 
 export function getCurrentBranch(): string {

--- a/test/commit-evidence-shell.test.ts
+++ b/test/commit-evidence-shell.test.ts
@@ -1,11 +1,11 @@
 import { runCommand, runCommandExpectFailure } from './test-util';
 
 function cmdCreateCommitEvidence(path: string): string {
-  return `git rev-parse HEAD > ${path}`;
+  return `git rev-parse HEAD^{tree} > ${path}`;
 }
 
 function cmdVerifyCommitEvidence(path: string): string {
-  return `git rev-parse HEAD | diff ${path} -`;
+  return `git rev-parse HEAD^{tree} | diff ${path} -`;
 }
 
 test('create verify success', async () => {

--- a/test/disable.test.ts
+++ b/test/disable.test.ts
@@ -50,6 +50,6 @@ test('disable feature branch - re-enable after branch switching', async () => {
   expect(output).toContain('Deleted');
   expect(output).toContain("capsafe.disable.json'");
   expect(output).toContain('Re-enabled capsafe because the current branch ');
-  expect(output).toContain("was not equal to branch 'some_feature_branch' in ");
+  expect(output).toContain("was not equal to branch 'feature_");
   expect(output).toContain('capsafe.disable.json');
 });

--- a/test/disable.test.ts
+++ b/test/disable.test.ts
@@ -7,7 +7,7 @@ import {
 } from './verify-commit-evidence.test';
 import { DisableFile } from '../src/resolve-context';
 
-async function switchToBranch(branchName: string) {
+export async function switchToBranch(branchName: string): Promise<void> {
   await runCommand(`git branch -d ${branchName} || true`);
   await runCommand(
     `git checkout -b ${branchName} || git checkout ${branchName}`,

--- a/test/disable.test.ts
+++ b/test/disable.test.ts
@@ -1,4 +1,4 @@
-import { runCapSafe, runCommand } from './test-util';
+import { runCapSafe, runCommand, switchToNewFeatureBranch } from './test-util';
 import { readJsonFile } from '../src/util';
 import { getCurrentBranch } from '../src/git-context';
 import {
@@ -6,13 +6,7 @@ import {
   verifyCommitEvidenceWrongCommitHash,
 } from './verify-commit-evidence.test';
 import { DisableFile } from '../src/resolve-context';
-
-export async function switchToBranch(branchName: string): Promise<void> {
-  await runCommand(`git branch -d ${branchName} || true`);
-  await runCommand(
-    `git checkout -b ${branchName} || git checkout ${branchName}`,
-  );
-}
+import { createCommitEvidenceSuccess } from './create-commit-evidence.test';
 
 async function runDisable(branchName: string) {
   const output = await runCapSafe(`disable`);
@@ -41,11 +35,9 @@ beforeEach(async () => {
 
 test('disable feature branch - re-enable after branch switching', async () => {
   const branchAtBegin = getCurrentBranch();
-  const featureBranch = 'some_feature_branch';
-  expect(branchAtBegin !== featureBranch).toBe(true);
+  const featureBranch = await switchToNewFeatureBranch();
 
-  await switchToBranch(featureBranch);
-
+  await createCommitEvidenceSuccess();
   await verifyCommitEvidenceSuccess();
 
   await runDisable(featureBranch);

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,6 +1,13 @@
 import { exec } from 'child_process';
 import { join } from 'path';
 
+export async function switchToNewFeatureBranch(): Promise<string> {
+  const randomString = Math.random().toString();
+  const branchName = `feature_${randomString}`;
+  await runCommand(`git checkout -b ${branchName}`);
+  return branchName;
+}
+
 function buildCapSafeCommand(args: string) {
   return `${join(process.cwd(), 'bin', 'capsafe')} ${args}`;
 }

--- a/test/verify-commit-evidence.test.ts
+++ b/test/verify-commit-evidence.test.ts
@@ -1,6 +1,11 @@
-import { runCapSafe, runCapSafeExpectFailure } from './test-util';
-import { getHEADCommitHash } from '../src/git-context';
+import { runCapSafe, runCapSafeExpectFailure, runCommand } from './test-util';
+import {
+  getCurrentBranch,
+  getHEADCommitHash,
+  getHEADTreeHash,
+} from '../src/git-context';
 import { createCommitEvidenceSuccess } from './create-commit-evidence.test';
+import { switchToBranch } from './disable.test';
 
 export async function verifyCommitEvidenceSuccess(): Promise<void> {
   const commitHash = getHEADCommitHash();
@@ -15,13 +20,24 @@ export async function verifyCommitEvidenceSuccess(): Promise<void> {
   );
 }
 
+async function verifyCommitEvidenceMatchingTreeHashes(): Promise<void> {
+  const treeHash = getHEADTreeHash();
+  const output = await runCapSafe(
+    `verify-commit-evidence test/create-evidence/`,
+  );
+  expect(output).toContain("Verification succeeded: '/");
+  expect(output).toContain(
+    `/test/create-evidence/commit-evidence.json\' is up-to-date with current tree ${treeHash}.\n`,
+  );
+}
+
 export async function verifyCommitEvidenceWrongCommitHash(): Promise<string> {
   const output = await runCapSafeExpectFailure(
     `verify-commit-evidence test/sample-evidence`,
   );
   expect(output).toContain('error: Current commit ');
   expect(output).toContain(
-    " is not equal to commit 0e827118c19e689ca08990a5c63b4567e884c153 in '/",
+    " does not match with commit 0e827118c19e689ca08990a5c63b4567e884c153 in '/",
   );
   expect(output).toContain(
     "/test/sample-evidence/commit-evidence.json'. Did you forget to build/sync with Capacitor?\n",
@@ -29,8 +45,29 @@ export async function verifyCommitEvidenceWrongCommitHash(): Promise<string> {
   return output;
 }
 
-test('verification success', async () => {
+test('verification success commits matching', async () => {
   await verifyCommitEvidenceSuccess();
+});
+
+test('amend commit message -> verify success -> add new commit -> verify fail', async () => {
+  const branchAtBegin = getCurrentBranch();
+  const featureBranch = 'some_other_feature_branch';
+  expect(branchAtBegin !== featureBranch).toBe(true);
+
+  await createCommitEvidenceSuccess();
+
+  await switchToBranch(featureBranch);
+
+  await runCommand("git commit --amend -m 'Some changed commit message'");
+
+  await verifyCommitEvidenceMatchingTreeHashes();
+
+  await runCommand('git add -f test/create-evidence/commit-evidence.json');
+  await runCommand('git commit -m "Some new commit"');
+
+  await verifyCommitEvidenceWrongCommitHash();
+
+  await runCommand(`git checkout ${branchAtBegin}`);
 });
 
 test('wrong commit hash', async () => {


### PR DESCRIPTION
This relaxes safety checks by looking at the actual tree contents instead of only comparing commits.